### PR TITLE
config*.yml (hook_beforetexcompile/pdfmaker): hookが走るディレクトリ変更に対応

### DIFF
--- a/config-print.yml
+++ b/config-print.yml
@@ -16,6 +16,6 @@ pdfmaker:
   #   % toc:break-before=page,%default: right
   #   % backmatter:break-before=page,%default: right
   texcommand: uplatex
-  hook_beforetexcompile: ../hook_beforetex.rb
+  hook_beforetexcompile: ./hook_beforetex.rb
   # hook_aftertexcompile: null
   ## end of pdfmaker

--- a/config-sp.yml
+++ b/config-sp.yml
@@ -16,6 +16,6 @@ pdfmaker:
   #   % toc:break-before=page,%default: right
   #   % backmatter:break-before=page,%default: right
   texcommand: uplatex
-  hook_beforetexcompile: ../hook_beforetex.rb
+  hook_beforetexcompile: ./hook_beforetex.rb
   # hook_aftertexcompile: null
   ## end of pdfmaker

--- a/config.yml
+++ b/config.yml
@@ -83,6 +83,6 @@ pdfmaker:
   #   % toc:break-before=page,%default: right
   #   % backmatter:break-before=page,%default: right
   texcommand: uplatex
-  hook_beforetexcompile: ../hook_beforetex.rb
+  hook_beforetexcompile: ./hook_beforetex.rb
   # hook_aftertexcompile: null
   ## end of pdfmaker


### PR DESCRIPTION
Re:VIEW 2.0.x と 2.1.x で pdfmaker に対する hook が走るディレクトリ変更に対応します。

tibooks-maker-2.0.0 から Re:VIEW 2.1.x に対する tibooks-maker-2.1.x への変更のための branch を devel-2.1 としました。