### PR TITLE
Devel v2.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,17 @@
 .DS_Store
+*~
+*.bak
+*.aux
+*.log
+*.dvi
+*.ps
+*.tar.xz
 
 .bundle/
 vendor/
 Gemfile.lock
+
+sty/texmf-thinkitcls.d/
 
 book-epub/
 book-pdf/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.DS_Store
+
+.bundle/
+vendor/
+Gemfile.lock
+
+book-epub/
+book-pdf/
+book.epub
+book.pdf

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gem "review", "~> 2.0.0"
-gem "math_ml"
-
-## end of file

--- a/README-pdfmaker.md
+++ b/README-pdfmaker.md
@@ -39,24 +39,41 @@ thinkit-books v2.1 において利用可能な主なクラスオプションは�
 ツメ有りのときの章総数を指定します。
 
 * chapter:total-number=6: 章総数を指定する（例：第6章まである場合、6）
+* appendixchapter:total-number=3: 章総数を指定する（例：付録Cまである場合、3）
 
 ### PDF埋込フォントプロファイル
 
-PDF埋込フォントプロファイルを指定します（後述のPDFデータ作成形式 `cameraready` 参照）。
+## pdf:kanjimap=preview,% default: preview; available: preview,release に変更
 
-* pdf:kanjimap=ipaex: PDF埋込するフォントを上書き指定する（例：フリーフォント）
-  * default: hiragino（OS X 10.11 El Capitan同梱ヒラギノフォント）
-  * hiragino-legacy（OS X 10.10 Yosemite 以前同梱ヒラギノフォント）
-  * morisawa（MORISAWA PASSPORTが必要）
-  * ipaex（フリーフォント）
+PDF埋込フォントプロファイルを指定します（後述のPDFデータ作成形式 `cameraready` 参照）。
+thinkitcls のLaTeXクラスファイルオプション pdf:kanjimap に対して、以下の値が利用できます。
+
+* pdf:kanjimap=preview: PDF埋込するフォントを上書き指定する（例：源ノ明朝、源ノ角ゴシック）
+   * preview: プレビュー用（源ノ明朝、源ノ角ゴシックで代替）
+   * release: 製品リリース用（主にMORISAWA PASSPORT）
+
+これまで利用していたpdf:kanjimapに与える値は、
+PDFに埋め込む和文フォントプロファイルとして、以下の値を指定していました。
+
+ * ipaex: フリーフォント（IPAex、Mig, Mogaなど）
+ * hiragino, hiragino-legacy: Mac OS Xに同梱されているヒラギノフォント
+ * morisawa: MORISAWA PASSPORT
+
+今回 tibooks-maker-2.3.0 の更新において、
+これらの値 ipaex, hiragino, hiragino-legacy, morisawa は、下位互換のために保持し、
+以下のような動作をします。
+
+ * ipaex, hiragino, hiragino-legacy: preview と同等
+ * morisawa: release と同等
+
 
 ### PDFデータ作成形式
 
 印刷用 `print`、閲覧用 `pdf`、プレビュー用 `preview` のいずれかの形式を指定します。
 
 * cameraready=pdf: データ作成形式を指定する（例：閲覧用PDF）
-  * preview: デフォルトで ipaex（フリーフォント）を埋め込む
-  * print, pdf: デフォルトで hiragino（OS X El Capitan同梱ヒラギノフォント）を埋め込む
+  * preview: デフォルトで preview（源ノ明朝、源ノ角ゴシック）を埋め込む
+  * print, pdf: デフォルトで preview（源ノ明朝、源ノ角ゴシック）を埋め込む
   * default: print; preview, pdf
 
 ### 用紙サイズ
@@ -180,4 +197,5 @@ tableタグの直前にtsizeで指定します、列数と合わせるように�
 ```
 //tsize[|latex|20,45,75]
 //table[table01][]{
+}
 ```

--- a/README.md
+++ b/README.md
@@ -20,23 +20,10 @@ Download the latest Version.
 
 ## Getting Started
 
-1. `tibooks-maker-X.Y.Z-YYYYMMDD.dmg` を開き `tibooks-maker` フォルダを `/Applications/` フォルダへコピーします。
-1. ターミナル `Terminal.app` を起動して、
-   `. /Applications/tibooks-maker/setup.sh` を実行すると、プロンプトが、
-   `tibooks-maker` 環境に切り替わります。
-    ```bash
-    $ . /Applications/tibooks-maker/setup.sh
-
-		tibook-maker 2.2.0-20170305 (Durian)
-
-        This is constructed from the following components:
-         * Re:VIEW:	review (2.2.0)
-         * Ruby:	ruby 2.3.3p222 (2016-11-21 revision 56859) [x86_64-darwin10.0]
-         * TeX Live
-           * uplatex:	e-upTeX 3.14159265-p3.6-u1.20-141210-2.6 (utf8.uptex) (TeX Live 2015)
-           * dvipdfmx:	dvipdfmx Version 20150315 
-
-    [tibooks-maker]:~ $
-    ```
+1. `tibooks-maker-X.Y.Z-YYYYMMDD.dmg`を開き、`tibooks-maker.app`を`/Applications/`フォルダへインストールします。
+1. `tibooks-maker.app`をダブルクリックしてRe:VIEW製作フォルダを開くと、`[tibooks-maker]` 環境のターミナル `Terminal.app` が起動します。
+    * `tibooks-maker.app`にRe:VIEW製作フォルダ（ファイル）をドラッグ＆ドロップすることもできます。
+    * ターミナル上で `$ open -a tibooks-maker -- Re:VIEW製作フォルダ`を実行してもかまいません。
+    * 旧版のように `$ . /Applications/tibooks-maker.app/setup.sh`を実行して、`[tibooks-maker]` 環境に移ることもできます。
 1. tibooks-makerリポジトリをクローンしたら、 `gmake all` コマンドを試してみましょう。
 book.epub: 電子書籍用EPUB（カラー画像）, book.pdf: 電子書籍用PDF, book-sp.pdf: 紙書籍用PDFの3点が生成されます。

--- a/hook_beforetex.rb
+++ b/hook_beforetex.rb
@@ -4,24 +4,31 @@
 require 'fileutils'
 
 def rewrite(fname)
-  File.open("#{ARGV[0]}/#{fname}") do |fi|
-    File.open("#{ARGV[0]}/#{fname}-n", "w") do |fo|
+  File.open("#{fname}") do |fi|
+    File.open("#{fname}-n", "w") do |fo|
       fo.puts yield(fi.readlines.join)
     end
   end
 end
 
-# 手動調整
+## 手動調整
+# Dir.glob("#{ARGV[0]}/*.tex").each do |f|
+#   rewrite(f) {|s|
+#     return nil if s.nil?
+#     ## some processes
+#
+#   }
+#   File.rename("#{f}-n", "#{f}")
+# end
 
 
-# Think IT 用著者紹介および奥付
-rewrite("book.tex") {|s|
-  s.gsub(/input\{(.+?)\.tex\}/, 'include{\1}').
-    sub('\include{terms}', '\begin{disclaimer}\include{terms}\end{disclaimer}').
-    sub('\include{profile}', '\begin{writers}\include{profile}\end{writers}').
-    sub('\include{okuduke}', '\begin{colophon}\include{okuduke}\end{colophon}')
-} 
-
-%w(book.tex).each do |f|
-  File.rename("#{ARGV[0]}/#{f}-n", "#{ARGV[0]}/#{f}")
+## Think IT 用著者紹介および奥付
+Dir.glob("#{ARGV[0]}/book.tex").each do |f|
+  rewrite("book.tex") {|s|
+    s.gsub(/input\{(.+?)\.tex\}/, 'include{\1}').
+      sub('\include{terms}', '\begin{disclaimer}\include{terms}\end{disclaimer}').
+      sub('\include{profile}', '\begin{writers}\include{profile}\end{writers}').
+      sub('\include{okuduke}', '\begin{colophon}\include{okuduke}\end{colophon}')
+  } 
+  File.rename("#{f}-n", "#{f}")
 end

--- a/review-ext.rb
+++ b/review-ext.rb
@@ -111,7 +111,7 @@ module ReVIEW
 
     def indepimage(id, caption=nil, metric=nil)
       metrics = parse_metric("latex", metric)
-      puts '\begin{reviewimage}'
+      puts '\begin{reviewindepimage}'
       if metrics.present?
         puts "\\includekeepaspectratiographics[#{metrics}]{#{@chapter.image(id).path}}"
       else
@@ -121,7 +121,7 @@ module ReVIEW
         puts macro('reviewindepimagecaption',
                    %Q[#{I18n.t("numberless_image")}#{I18n.t("caption_prefix")}#{compile_inline(caption)}])
       end
-      puts '\end{reviewimage}'
+      puts '\end{reviewindepimage}'
     end
 
     # def index(str)


### PR DESCRIPTION
tibooks-maker-2.3.0-20171029.dmg ＋ devel-2.3.0 で以下に対応いたします。

 * [x] Re:VIEW 2.3.0対応 #28
 * [x] High Sierra環境でのヒラギノフォント問題 #29
 * [x] アクセント付きラテン文字などの処理がうまくいかない #32
 * [x] chapter:total-numberオプションオフでも付録のツメが表示される #26
 * [x] apostropheとbacktickの扱い #9
 * [x] indepimageの挙動がおかしい #23
 * 画像フォルダーとMakefileの再考 #31
    * [x] 画像フォルダーとMakefileの再考
    * [x] `/ArtBox` の除去
