### PR TITLE
layouts/layout.tex.erb: supported makind indexes (\printindex) with pdfmaker

### DIFF
--- a/layouts/layout.tex.erb
+++ b/layouts/layout.tex.erb
@@ -31,6 +31,9 @@
 
 <%- if @input_files["POSTDEF"] -%>
 \backmatter
+<%- if @config["pdfmaker"]["makeindex"] -%>
+\printindex
+<%- end -%>
 <%= @input_files["POSTDEF"] %>
 <% end %>
 \end{document}


### PR DESCRIPTION
`makeindex: true` のとき、テンプレート 'layouts/layout.tex.erb' に対して、「索引」を対応させます。
